### PR TITLE
Allow silent curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,18 @@ authentication is assumed not to be required. If configured, it must follow the 
 The default endpoint type is JSON. The argument is only required if you wish to send urlencoded form data. 
 Otherwise it's optional. <br/><br/>
 
+
+```yml 
+  silent: true
+```
+
+To hide the output from curl set the argument `silent` to `true`. The default value is `false`.<br/><br/>
+
+
 ```yml 
   data: "Additional JSON or URL encoded data"
 ```
+
 
 Additional data to include in the payload. It is optional. This data will attempted to be 
 merged 'as-is' with the existing payload, and is expected to already be sanitized and valid.

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,10 @@ inputs:
     required: true
   webhook_auth:
     description: 'Credentials to be used for BASIC authentication (optional)'
-  webhook_type: 'json | form-urlencoded | json-extended'
+  webhook_type: 
+    description: 'json | form-urlencoded | json-extended'
+  silent:
+    description: 'Optional, set to true to disable output and therefore IP leaking'
   data:
     description: 'Optional additional data to include in the payload'
     

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,7 +72,7 @@ if [ -n "$webhook_auth" ]; then
 fi
 
 
-if [ "$silent"]; then
+if [ "$silent" ]; then
     curl -k -v --fail -s \
         -H "Content-Type: $CONTENT_TYPE" \
         -H "User-Agent: User-Agent: GitHub-Hookshot/760256b" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,10 +71,21 @@ if [ -n "$webhook_auth" ]; then
     WEBHOOK_ENDPOINT="-u $webhook_auth $webhook_url"
 fi
 
-curl -k -v --fail \
-    -H "Content-Type: $CONTENT_TYPE" \
-    -H "User-Agent: User-Agent: GitHub-Hookshot/760256b" \
-    -H "X-Hub-Signature: sha1=$WEBHOOK_SIGNATURE" \
-    -H "X-GitHub-Delivery: $GITHUB_RUN_NUMBER" \
-    -H "X-GitHub-Event: $GITHUB_EVENT_NAME" \
-    --data "$WEBHOOK_DATA" $WEBHOOK_ENDPOINT
+
+if [ "$silent"]; then
+    curl -k -v --fail -s \
+        -H "Content-Type: $CONTENT_TYPE" \
+        -H "User-Agent: User-Agent: GitHub-Hookshot/760256b" \
+        -H "X-Hub-Signature: sha1=$WEBHOOK_SIGNATURE" \
+        -H "X-GitHub-Delivery: $GITHUB_RUN_NUMBER" \
+        -H "X-GitHub-Event: $GITHUB_EVENT_NAME" \
+        --data "$WEBHOOK_DATA" $WEBHOOK_ENDPOINT
+else
+    curl -k -v --fail \
+        -H "Content-Type: $CONTENT_TYPE" \
+        -H "User-Agent: User-Agent: GitHub-Hookshot/760256b" \
+        -H "X-Hub-Signature: sha1=$WEBHOOK_SIGNATURE" \
+        -H "X-GitHub-Delivery: $GITHUB_RUN_NUMBER" \
+        -H "X-GitHub-Event: $GITHUB_EVENT_NAME" \
+        --data "$WEBHOOK_DATA" $WEBHOOK_ENDPOINT
+fi


### PR DESCRIPTION
If you add the -s parameter to curl, you can prevent that the webhook endpoint gets leaked by stdout. 
With this PR you'll be able to enable that silent mode by setting `silent` to `true` in your workflow.