### PR TITLE
Verify SSL certificates by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ Otherwise it's optional. <br/><br/>
 
 To hide the output from curl set the argument `silent` to `true`. The default value is `false`.<br/><br/>
 
+```yml 
+  verify_ssl: false
+```
+
+To disable verification of SSL-certificates in curl set the argument `verify_ssl` to `false`. The default value is `true`. See also: [`curl` docs on option `-k`](https://curl.se/docs/manpage.html#-k).<br/><br/>
+
 
 ```yml 
   data: "Additional JSON or URL encoded data"

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
     description: 'json | form-urlencoded | json-extended'
   silent:
     description: 'Optional, set to true to disable output and therefore IP leaking'
+  verify_ssl:
+    description: 'Optional, set to false to disable verification of SSL certificates'
+    default: true
   data:
     description: 'Optional additional data to include in the payload'
     

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,23 +71,19 @@ if [ -n "$webhook_auth" ]; then
     WEBHOOK_ENDPOINT="-u $webhook_auth $webhook_url"
 fi
 
+options="--http1.1 --fail -k"
 
 if [ "$silent" ]; then
-    curl -k -v --http1.1 --fail -s \
-        -H "Content-Type: $CONTENT_TYPE" \
-        -H "User-Agent: User-Agent: GitHub-Hookshot/760256b" \
-        -H "X-Hub-Signature: sha1=$WEBHOOK_SIGNATURE" \
-        -H "X-Hub-Signature-256: sha256=$WEBHOOK_SIGNATURE_256" \
-        -H "X-GitHub-Delivery: $GITHUB_RUN_NUMBER" \
-        -H "X-GitHub-Event: $GITHUB_EVENT_NAME" \
-        --data "$WEBHOOK_DATA" $WEBHOOK_ENDPOINT &> /dev/null
+    options="$options -s"
 else
-    curl -k -v --http1.1 --fail \
-        -H "Content-Type: $CONTENT_TYPE" \
-        -H "User-Agent: User-Agent: GitHub-Hookshot/760256b" \
-        -H "X-Hub-Signature: sha1=$WEBHOOK_SIGNATURE" \
-        -H "X-Hub-Signature-256: sha256=$WEBHOOK_SIGNATURE_256" \
-        -H "X-GitHub-Delivery: $GITHUB_RUN_NUMBER" \
-        -H "X-GitHub-Event: $GITHUB_EVENT_NAME" \
-        --data "$WEBHOOK_DATA" $WEBHOOK_ENDPOINT
+    options="$options -v"
 fi
+
+curl $options \
+    -H "Content-Type: $CONTENT_TYPE" \
+    -H "User-Agent: User-Agent: GitHub-Hookshot/760256b" \
+    -H "X-Hub-Signature: sha1=$WEBHOOK_SIGNATURE" \
+    -H "X-Hub-Signature-256: sha256=$WEBHOOK_SIGNATURE_256" \
+    -H "X-GitHub-Delivery: $GITHUB_RUN_NUMBER" \
+    -H "X-GitHub-Event: $GITHUB_EVENT_NAME" \
+    --data "$WEBHOOK_DATA" $WEBHOOK_ENDPOINT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,12 +71,16 @@ if [ -n "$webhook_auth" ]; then
     WEBHOOK_ENDPOINT="-u $webhook_auth $webhook_url"
 fi
 
-options="--http1.1 --fail -k"
+options="--http1.1 --fail"
 
 if [ "$silent" ]; then
     options="$options -s"
 else
     options="$options -v"
+fi
+
+if [ "$verify_ssl" = false ]; then
+    options="$options -k"
 fi
 
 curl $options \


### PR DESCRIPTION
Merging this PR closes #20.

>The current implementation does not verify SSL certificates, if I correctly understand the curl docs on option -k. This parameter was introduced in 16b7ccd as a response to #3.
>
>I can see how some people do not have the time, patience or even the option to use verifiable SSL certificates, but I do and so will others.

The code in this PR makes verification of SSL certificates the default (corresponds to approach 1 mentioned in #20). This has the benefit that the most secure option is used by default, but might break other peoples' workflows if they use unsigned certificates and would require them to update their workflow config.

If you want certificate verification not to be the default, I can modifiy this PR. If you want to do the change yourself, feel free to do so as well.

This PR also cleans up some of the code by storing the options in a variable and therefore allowing one of the `curl` sections to be removed. Also: `&> /dev/null` is not needed if `-v` is omitted and `-s` is used and therefore removed.

~**Disclaimer:** I'm not fully able to test this as a proper GitHub Action in one of my projects. I therefore tested the code by running the docker container with the same environment variables, that I believe GitHub would use.~

Code fully tested using:
```yml
    - name: Invoke deployment hook
      uses: johannes-huther/workflow-webhook@feature/verify-certificates
      env:
        webhook_url: ${{ secrets.WEBHOOK_URL }}
        webhook_secret: ${{ secrets.WEBHOOK_SECRET }}
```

Also tested with `verify_ssl: false` and `silent: true`.
