### PR TITLE
Add new log level (closes #21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ authentication is assumed not to be required. If configured, it must follow the 
 The default endpoint type is JSON. The argument is only required if you wish to send urlencoded form data. 
 Otherwise it's optional. <br/><br/>
 
+```yml
+  verbose: true
+```
+
+To enable verbose output in curl set the argument `verbose` to `true`. The default value is `false`. See also: [`curl` docs on option `-v`](https://curl.se/docs/manpage.html#-v).
+
+:warning: **Warning:** This might lead to domain and IP leaking, as well as other security issues as the logs are public. See also [#21](https://github.com/distributhor/workflow-webhook/issues/21) and [#22](https://github.com/distributhor/workflow-webhook/issues/22). :warning:<br/><br/>
+
 
 ```yml 
   silent: true

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,8 @@ inputs:
     description: 'Credentials to be used for BASIC authentication (optional)'
   webhook_type: 
     description: 'json | form-urlencoded | json-extended'
+  verbose:
+    description: 'Optional, set to true to enable verbose output. Warning: this might lead to domain and IP leaking, as well as other security issues as the logs are public.'
   silent:
     description: 'Optional, set to true to disable output and therefore IP leaking'
   data:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,23 +71,19 @@ if [ -n "$webhook_auth" ]; then
     WEBHOOK_ENDPOINT="-u $webhook_auth $webhook_url"
 fi
 
+options="--http1.1 --fail -k"
 
 if [ "$silent" ]; then
-    curl -k -v --http1.1 --fail -s \
-        -H "Content-Type: $CONTENT_TYPE" \
-        -H "User-Agent: User-Agent: GitHub-Hookshot/760256b" \
-        -H "X-Hub-Signature: sha1=$WEBHOOK_SIGNATURE" \
-        -H "X-Hub-Signature-256: sha256=$WEBHOOK_SIGNATURE_256" \
-        -H "X-GitHub-Delivery: $GITHUB_RUN_NUMBER" \
-        -H "X-GitHub-Event: $GITHUB_EVENT_NAME" \
-        --data "$WEBHOOK_DATA" $WEBHOOK_ENDPOINT &> /dev/null
+    options="$options -s"
 else
-    curl -k -v --http1.1 --fail \
-        -H "Content-Type: $CONTENT_TYPE" \
-        -H "User-Agent: User-Agent: GitHub-Hookshot/760256b" \
-        -H "X-Hub-Signature: sha1=$WEBHOOK_SIGNATURE" \
-        -H "X-Hub-Signature-256: sha256=$WEBHOOK_SIGNATURE_256" \
-        -H "X-GitHub-Delivery: $GITHUB_RUN_NUMBER" \
-        -H "X-GitHub-Event: $GITHUB_EVENT_NAME" \
-        --data "$WEBHOOK_DATA" $WEBHOOK_ENDPOINT
+    options="$options -v"
 fi
+
+curl $options \
+    -H "Content-Type: $CONTENT_TYPE" \
+    -H "User-Agent: User-Agent: GitHub-Hookshot/760256b" \
+    -H "X-Hub-Signature: sha1=$WEBHOOK_SIGNATURE" \
+    -H "X-Hub-Signature-256: sha256=$WEBHOOK_SIGNATURE_256" \
+    -H "X-GitHub-Delivery: $GITHUB_RUN_NUMBER" \
+    -H "X-GitHub-Event: $GITHUB_EVENT_NAME" \
+    --data "$WEBHOOK_DATA" $WEBHOOK_ENDPOINT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,10 +73,10 @@ fi
 
 options="--http1.1 --fail -k"
 
-if [ "$silent" ]; then
-    options="$options -s"
-else
+if [ "$verbose" = true ]; then
     options="$options -v"
+elif [ "$silent" = true ]; then
+    options="$options -s"
 fi
 
 curl $options \


### PR DESCRIPTION
Adds a new log level between `--verbose` and `--silent`.

Defaults to the new log level. Added new option `verbose` that re-enables verbose output (previous default) if set to `true`.

This allows easier debugging without entirely compromising on privacy and security (domain, IP addresses etc.). For more details see #21.

This also reduces the propability of replay attacks as mentioned in #22, as the signatures are no longer logged by default.

If you still want verbose to be the default, I can modifiy this PR. If you want to do the change yourself, feel free to do so as well.

Code fully tested using:
```yml
    - name: Invoke deployment hook
      uses: johannes-huther/workflow-webhook@feature/new-log-level
      env:
        webhook_url: ${{ secrets.WEBHOOK_URL }}
        webhook_secret: ${{ secrets.WEBHOOK_SECRET }}
```

Also tested with `verbose: true` and `silent: true`.
