### PR TITLE
Add random request ID (closes #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,12 @@ Will deliver a payload with the following properties:
     "commit": "a636b6f0861bbee98039bf3df66ee13d8fbc9c74",
     "ref": "refs/heads/master",
     "head": "",
-    "workflow": "Build and deploy"
+    "workflow": "Build and deploy",
+    "requestID": "74b1912d19cfe780f1fada4b525777fd"
 }
 ```
+`requestID` contains a randomly generated identifier for each request. 
+
 <br/>
 
 Add additional data to the payload:
@@ -92,7 +95,8 @@ and now look like:
     "data": {
         "weapon": "hammer",
         "drink": "beer"
-    }
+    },
+    "requestID": "74b1912d19cfe780f1fada4b525777fd"
 }
 ```
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,6 +29,8 @@ if [ -z "$webhook_secret" ]; then
     exit 1
 fi
 
+REQUEST_ID=$(cat /dev/urandom | tr -dc '0-9a-f' | fold -w 32 | head -n 1)
+
 if [ -n "$webhook_type" ] && [ "$webhook_type" == "form-urlencoded" ]; then
 
     EVENT=`urlencode "$GITHUB_EVENT_NAME"`
@@ -39,7 +41,7 @@ if [ -n "$webhook_type" ] && [ "$webhook_type" == "form-urlencoded" ]; then
     WORKFLOW=`urlencode "$GITHUB_WORKFLOW"`
 
     CONTENT_TYPE="application/x-www-form-urlencoded"
-    WEBHOOK_DATA="event=$EVENT&repository=$REPOSITORY&commit=$COMMIT&ref=$REF&head=$HEAD&workflow=$WORKFLOW"
+    WEBHOOK_DATA="event=$EVENT&repository=$REPOSITORY&commit=$COMMIT&ref=$REF&head=$HEAD&workflow=$WORKFLOW&requestID=$REQUEST_ID"
 
     if [ -n "$data" ]; then
         WEBHOOK_DATA="${WEBHOOK_DATA}&${data}"
@@ -55,10 +57,13 @@ else
     else
         WEBHOOK_DATA="{\"event\":\"$GITHUB_EVENT_NAME\",\"repository\":\"$GITHUB_REPOSITORY\",\"commit\":\"$GITHUB_SHA\",\"ref\":\"$GITHUB_REF\",\"head\":\"$GITHUB_HEAD_REF\",\"workflow\":\"$GITHUB_WORKFLOW\"}"
     fi
+    
+    JSON_WITH_OPEN_CLOSE_BRACKETS_STRIPPED=`echo "$WEBHOOK_DATA" | sed 's/^{\(.*\)}$/\1/'`
     if [ -n "$data" ]; then
         CUSTOM_JSON_DATA=$(echo -n "$data" | jq -c '')
-        JSON_WITH_OPEN_CLOSE_BRACKETS_STRIPPED=`echo "$WEBHOOK_DATA" | sed 's/^{\(.*\)}$/\1/'`
-        WEBHOOK_DATA="{$JSON_WITH_OPEN_CLOSE_BRACKETS_STRIPPED,\"data\":$CUSTOM_JSON_DATA}"
+        WEBHOOK_DATA="{$JSON_WITH_OPEN_CLOSE_BRACKETS_STRIPPED,\"data\":$CUSTOM_JSON_DATA,\"requestID\":\"$REQUEST_ID\"}"
+    else
+        WEBHOOK_DATA="{$JSON_WITH_OPEN_CLOSE_BRACKETS_STRIPPED,\"requestID\":\"$REQUEST_ID\"}"
     fi
 
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,23 +71,19 @@ if [ -n "$webhook_auth" ]; then
     WEBHOOK_ENDPOINT="-u $webhook_auth $webhook_url"
 fi
 
+options="--http1.1 --fail -k"
 
 if [ "$silent" ]; then
-    curl -k -v --http1.1 --fail -s \
-        -H "Content-Type: $CONTENT_TYPE" \
-        -H "User-Agent: User-Agent: GitHub-Hookshot/760256b" \
-        -H "X-Hub-Signature: sha1=$WEBHOOK_SIGNATURE" \
-        -H "X-Hub-Signature-256: sha256=$WEBHOOK_SIGNATURE_256" \
-        -H "X-GitHub-Delivery: $GITHUB_RUN_NUMBER" \
-        -H "X-GitHub-Event: $GITHUB_EVENT_NAME" \
-        --data "$WEBHOOK_DATA" $WEBHOOK_ENDPOINT &> /dev/null
+    options="$options -s"
 else
-    curl -k -v --http1.1 --fail \
-        -H "Content-Type: $CONTENT_TYPE" \
-        -H "User-Agent: User-Agent: GitHub-Hookshot/760256b" \
-        -H "X-Hub-Signature: sha1=$WEBHOOK_SIGNATURE" \
-        -H "X-Hub-Signature-256: sha256=$WEBHOOK_SIGNATURE_256" \
-        -H "X-GitHub-Delivery: $GITHUB_RUN_NUMBER" \
-        -H "X-GitHub-Event: $GITHUB_EVENT_NAME" \
-        --data "$WEBHOOK_DATA" $WEBHOOK_ENDPOINT
+    options="$options -v"
 fi
+
+curl $options \
+    -H "Content-Type: $CONTENT_TYPE" \
+    -H "User-Agent: User-Agent: GitHub-Hookshot/760256b" \
+    -H "X-Hub-Signature: sha1=$WEBHOOK_SIGNATURE" \
+    -H "X-Hub-Signature-256: sha256=$WEBHOOK_SIGNATURE_256" \
+    -H "X-GitHub-Delivery: $GITHUB_RUN_NUMBER" \
+    -H "X-GitHub-Event: $GITHUB_EVENT_NAME" \
+    --data "$WEBHOOK_DATA" $WEBHOOK_ENDPOINT


### PR DESCRIPTION
Adds a random unique ID to the request. 

As the POST data is never logged, this should prevent replay attacks even if logging is set to verbose.

If the randomness is not trusted an additional salt can still be added using 
```yml 
data: '{ "salt": "${{ secrets.WEBHOOK_SALT }}" }'
``` 
but this shouldn't be necessary.

Also the user can verify, that the request is unique by storing the previous request IDs. But I don't think this is necessary either. 

Therefore I conclude that this PR closes #22.