### PR TITLE
Adding custom event_name and UUID to Delivery header

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,9 @@ inputs:
     description: 'Optional, set to false to disable verification of SSL certificates'
     default: true
   data:
-    description: 'Optional additional data to include in the payload'
+    description: 'Optional, additional data to include in the payload'
+  event_name:
+    description: 'Optional, The name of the event sent to the webhook endpoint, if no custom name is defined it will default to GITHUB_EVENT_NAME'
     
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -110,11 +110,17 @@ if [ "$verbose" = true ]; then
     echo "Options: $options"
 fi
 
+if [ -n "$event_name" ]; then
+    EVENT_NAME=$event_name
+else
+    EVENT_NAME=$GITHUB_EVENT_NAME
+fi
+
 curl $options \
     -H "Content-Type: $CONTENT_TYPE" \
     -H "User-Agent: GitHub-Hookshot/760256b" \
     -H "X-Hub-Signature: sha1=$WEBHOOK_SIGNATURE" \
     -H "X-Hub-Signature-256: sha256=$WEBHOOK_SIGNATURE_256" \
-    -H "X-GitHub-Delivery: $GITHUB_RUN_NUMBER" \
-    -H "X-GitHub-Event: $GITHUB_EVENT_NAME" \
+    -H "X-GitHub-Delivery: $REQUEST_ID" \
+    -H "X-GitHub-Event: $EVENT_NAME" \
     --data "$WEBHOOK_DATA" $WEBHOOK_ENDPOINT


### PR DESCRIPTION
This PR adds:

Custom event names to be passed as an option in case the webhook integration requires specific names.
It changes the value of `X-GitHub-Delivery:` to a UUID since that is the standard value set on github webhooks