### PR TITLE
Add support for curl --max-time option

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,13 @@ To hide the output from curl set the argument `silent` to `true`. The default va
 To set a maximum time, in seconds, by which to establish an initial connection to the server. Once a connection has been
 established, the option is not used in any further way with regards to the duration of connection.<br/><br/>
 
+```yml
+  max_time: 30
+```
+
+To set a maximum time, in seconds, by which the server needs to respond to the POST request.
+This also includes the time needed for the server to respond. May be used in combination with `timeout`.<br/><br/>
+
 ```yml 
   verify_ssl: false
 ```

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,8 @@ inputs:
     description: 'Optional, set to true to disable output and therefore IP leaking'
   timeout:
     description: 'Optional, set a maximum time, in seconds, by which to establish a connection to the server'
+  max_time:
+    description: 'Optional, set a maximum time, in seconds, the request to the server can take, before being cancelled'
   verify_ssl:
     description: 'Optional, set to false to disable verification of SSL certificates'
     default: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -111,6 +111,10 @@ if [ -n "$timeout" ]; then
     options="$options --connect-timeout $timeout"
 fi
 
+if [ -n "$max_time" ]; then
+    options="$options --max-time $max_time"
+fi
+
 if [ "$verbose" = true ]; then
     echo "Options: $options"
 fi


### PR DESCRIPTION
Adds support for curls "--max-time" option. The default is 60 seconds, which is not enough, if you are, for example, building an app before responding to the webhook request.