### PR TITLE
Update entrypoint.sh :: Convert envs to lowercase & remove `input_`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
     description: 'Optional. Set a maximum time, in seconds, the request to the server can take, before being cancelled.'
   curl_opts:
     description: 'Optional (and experimental). Pass arbitrary options to the curl request.'
+  curl_connection_close:
+    description: 'Optional. Set to true to add the "Connection: close" header to the request.'
+    default: true
   verify_ssl:
     description: 'Optional. Set to false to disable verification of SSL certificates.'
     default: true


### PR DESCRIPTION
I'd like to suggest the following features:

- Iterate over environment variables starting with INPUT_ and export them as lowercase variables without input_ prefix.
    - I don't think you need the `elif [ -n "$MAX_TIME" ]; then; max_time=$MAX_TIME; fi` blocks because users should only use the inputs from a `with` directive as described in all the readme.
- Add a trap config to print the line number of any errors. This was immensely useful for my team to debug and understand how to use your action. 
- Add `Connection: close` header to curl requests.
    - Helps the CURL requests exit faster as well as letting the targets release their connection faster. Too many `/github-webhook/` calls on Jenkins instances cause latency from my experience.
- Update `User-Agent: GitHub-Hookshot/$REQUEST_ID` to be dynamic. 
    - The [Delivery headers](https://docs.github.com/en/webhooks/webhook-events-and-payloads#delivery-headers) docs don't really explain how this header is used but should it be hard-coded to some value we don't know what it means?
 - Change to build headers & auth_header just like the curl_options. This way we can have just 1 place we actually make a curl request.
 - Add `curl_connection_close` input to optionally disable adding of the `-H Connection: close` header.