### PR TITLE
Use the latest action version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Add additional data to the payload:
 
 ```yml
     - name: Invoke deployment hook
-      uses: distributhor/workflow-webhook@v2
+      uses: distributhor/workflow-webhook@v3
       with:
         webhook_url: ${{ secrets.WEBHOOK_URL }}
         webhook_secret: ${{ secrets.WEBHOOK_SECRET }}


### PR DESCRIPTION
I copy pasted this sniplet from the README and had various issues getting my config to work only to realise I was using `@v2` instead of `@v3`.

Fixing README here to be consistent with the rest of the examples.